### PR TITLE
Fixed Display showing item after removal

### DIFF
--- a/common/src/main/java/com/berksire/furniture/core/block/entity/DisplayBlockEntity.java
+++ b/common/src/main/java/com/berksire/furniture/core/block/entity/DisplayBlockEntity.java
@@ -52,6 +52,8 @@ public class DisplayBlockEntity extends BlockEntity implements Clearable {
         CompoundTag compoundTag = new CompoundTag();
         if (!this.displayedItem.isEmpty()) {
             compoundTag.put("DisplayedItem", this.displayedItem.save(provider));
+        } else {
+            compoundTag.put("DisplayedItem", new CompoundTag());
         }
         return compoundTag;
     }


### PR DESCRIPTION
Addresses [Issue #1036](https://github.com/Let-s-Do-Collection/Let-s-Do-Collection/issues/1036)

**Change(s) Made**
Added an else statement so that if an item was removed, getUpdateTag in DisplayBlockEntity's returns a new, empty CompoundTag instead of nothing. 

**Why it fixes the problem**
The else statement makes it so that the Display actually knows that the item was removed, fixing the issue. Before, if an item was removed from the display case, it would still be visible inside of it until a new item is placed or the Display is broken.

